### PR TITLE
fix cpp compile error

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -208,6 +208,14 @@ menu "Board Support Package (generic)"
             default n
             help
                 Whether to enable double framebuf.
+
+        config BSP_LVGL_PORT_TASK_STACK_SIZE
+            int "LVGL port task stack size (bytes)"
+            default 0
+            range 0 65536
+            help
+                Specifies the stack size for the LVGL port task in bytes.
+                If set to 0, the default stack size defined by the LVGL port will be used.
     endmenu
 
 endmenu

--- a/include/bsp/bsp_generic.h
+++ b/include/bsp/bsp_generic.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "sdkconfig.h"
 #include "driver/i2c_master.h"
 
 #include "bsp/display.h"
 #include "esp_lvgl_port.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // Pinout
 

--- a/src/bsp_generic.c
+++ b/src/bsp_generic.c
@@ -307,6 +307,9 @@ lv_display_t *bsp_display_start(void)
                 .buff_spiram = false,
             },
     };
+    if (CONFIG_BSP_LVGL_PORT_TASK_STACK_SIZE > 0) {
+        cfg.lvgl_port_cfg.task_stack = CONFIG_BSP_LVGL_PORT_TASK_STACK_SIZE;
+    }
     return bsp_display_start_with_config(&cfg);
 }
 


### PR DESCRIPTION
Has a compilation error in your C++ code due to an #include directive inside an extern "C" block. To resolve this, need to move the #include directive outside of the extern "C" block. 

In file included from /Users/xxx/esp/esp-idf/components/esp_lcd/include/esp_lcd_panel_io.h:12,
                 from /Users/xxx/esp/xxxxxx/managed_components/espressif__esp_lvgl_port/include/esp_lvgl_port_disp.h:15,
                 from /Users/xxx/esp/xxxxxx/managed_components/espressif__esp_lvgl_port/include/esp_lvgl_port.h:16,
                 from /Users/xxx/esp/xxxxxx/managed_components/larryli__bsp_generic/include/bsp/bsp_generic.h:11,
                 from /Users/xxx/esp/xxxxxx/managed_components/larryli__bsp_generic/include/bsp/esp-bsp.h:2,
                 from /Users/xxx/esp/xxxxxx/components/display/display_state.cpp:7:
/Users/xxx/esp/esp-idf/components/esp_lcd/include/esp_lcd_io_i2c.h:102:25: error: conflicting declaration of C function 'esp_err_t esp_lcd_new_panel_io_i2c(i2c_master_bus_handle_t, const esp_lcd_panel_io_i2c_config_t*, esp_lcd_panel_io_t**)'
  102 | static inline esp_err_t esp_lcd_new_panel_io_i2c(i2c_master_bus_handle_t bus, const esp_lcd_panel_io_i2c_config_t *io_config, esp_lcd_panel_io_handle_t *ret_io)
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/xxx/esp/esp-idf/components/esp_lcd/include/esp_lcd_io_i2c.h:86:25: note: previous declaration 'esp_err_t esp_lcd_new_panel_io_i2c(uint32_t, const esp_lcd_panel_io_i2c_config_t*, esp_lcd_panel_io_t**)'
   86 | static inline esp_err_t esp_lcd_new_panel_io_i2c(uint32_t bus, const esp_lcd_panel_io_i2c_config_t *io_config, esp_lcd_panel_io_handle_t *ret_io)
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~

