### PR TITLE
add display configuration retrieval

### DIFF
--- a/include/bsp/bsp_generic.h
+++ b/include/bsp/bsp_generic.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "sdkconfig.h"
 #include "driver/i2c_master.h"
+#include "esp_lvgl_port_disp.h"
+#include "sdkconfig.h"
 
 #include "bsp/display.h"
 #include "esp_lvgl_port.h"
@@ -49,6 +50,7 @@ extern i2c_master_bus_handle_t bsp_i2c_bus_handle;
 lv_display_t *bsp_display_start(void);
 lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg);
 lv_indev_t *bsp_display_get_input_dev(void);
+lvgl_port_display_cfg_t *bsp_display_get_config(void);
 bool bsp_display_lock(uint32_t timeout_ms);
 void bsp_display_unlock(void);
 void bsp_display_rotate(lv_disp_t *disp, lv_display_rotation_t rotation);

--- a/src/bsp_generic.c
+++ b/src/bsp_generic.c
@@ -31,6 +31,8 @@ static const char *TAG = "bsp_generic";
 
 static lv_display_t *disp;
 
+static lvgl_port_display_cfg_t display_cfg;
+
 static bool i2c_initialized = false;
 
 i2c_master_bus_handle_t bsp_i2c_bus_handle;
@@ -288,6 +290,7 @@ static lv_display_t *bsp_display_lcd_init(const bsp_display_cfg_t *cfg)
 #endif
         }};
 
+    display_cfg = disp_cfg;
     return lvgl_port_add_disp(&disp_cfg);
 }
 
@@ -326,6 +329,8 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
 }
 
 lv_indev_t *bsp_display_get_input_dev(void) { return NULL; }
+
+lvgl_port_display_cfg_t *bsp_display_get_config(void) { return &display_cfg; }
 
 void bsp_display_rotate(lv_disp_t *disp, lv_display_rotation_t rotation)
 {


### PR DESCRIPTION
When the display is rotated, you need to set the gap again, so it's necessary to get the panel_handle.